### PR TITLE
Update chart version and image release tag

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,11 @@
 FROM python:3.10-slim
 WORKDIR /app
 
+# Install process tools for startup probes, and apply latest minor patchsets from base tag
+ENV DEBIAN_FRONTEND=noninteractive
+RUN apt-get update -y && apt-get install --no-install-recommends -y procps curl && apt-get upgrade -y && rm -rf /var/lib/apt/lists/*
+# RUN dpkg -r --force-all apt apt-get && dpkg -r --force-all debconf dpkg
+
 # Copy required files
 COPY requirements.txt ./
 COPY *.py ./
@@ -26,7 +31,7 @@ RUN rm -rf /tmp/*
 RUN useradd -c 'Sealed Secrets UI user' -m -d /app -s /bin/bash sealedsecrets
 RUN chown -R sealedsecrets.sealedsecrets /app
 USER sealedsecrets
-ENV HOME /app
+ENV HOME=/app
 
 # Setup Path
 RUN mkdir -p .local/bin

--- a/charts/sealed-secrets-ui/Chart.yaml
+++ b/charts/sealed-secrets-ui/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: sealed-secrets-ui
 description: A Helm chart for a Sealed Secrets web interface
 type: application
-version: 0.0.7
-appVersion: v0.1.3
+version: 0.0.8
+appVersion: v0.1.4

--- a/charts/sealed-secrets-ui/Chart.yaml
+++ b/charts/sealed-secrets-ui/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: sealed-secrets-ui
 description: A Helm chart for a Sealed Secrets web interface
 type: application
-version: 0.0.8
-appVersion: v0.1.4
+version: 0.0.7
+appVersion: v0.1.3

--- a/charts/sealed-secrets-ui/templates/configmap.yaml
+++ b/charts/sealed-secrets-ui/templates/configmap.yaml
@@ -19,3 +19,5 @@ data:
 kind: ConfigMap
 metadata:
   name: {{ include "chart.fullname" . }}
+  labels:
+    {{- include "chart.labels" . | nindent 4 }}

--- a/charts/sealed-secrets-ui/templates/deployment.yaml
+++ b/charts/sealed-secrets-ui/templates/deployment.yaml
@@ -4,6 +4,10 @@ metadata:
   name: {{ include "chart.fullname" . }}
   labels:
     {{- include "chart.labels" . | nindent 4 }}
+    {{- with .Values.annotations }}
+  annotations:
+      {{- toYaml . | nindent 4 }}
+    {{- end }}
 spec:
   {{- if not .Values.autoscaling.enabled }}
   replicas: {{ .Values.replicaCount }}
@@ -40,22 +44,25 @@ spec:
             - name: http
               containerPort: 5000
               protocol: TCP
+          {{- with .Values.livenessProbe }}
           livenessProbe:
-            httpGet:
-              {{- if not .Values.configs.basePath }}
-              path: /
-              {{- else }}
-              path: {{ .Values.configs.basePath }}/
-              {{- end }}
-              port: http
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.readinessProbe }}
           readinessProbe:
-            httpGet:
-              {{- if not .Values.configs.basePath }}
-              path: /
-              {{- else }}
-              path: {{ .Values.configs.basePath }}/
-              {{- end }}
-              port: http
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.startupProbe }}          
+          startupProbe:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.lifecycle }}
+          lifecycle:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- if .Values.priorityClassName }}
+          priorityClassName: {{ .Values.priorityClassName }}
+          {{- end }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
           volumeMounts:

--- a/charts/sealed-secrets-ui/templates/hpa.yaml
+++ b/charts/sealed-secrets-ui/templates/hpa.yaml
@@ -1,10 +1,14 @@
 {{- if .Values.autoscaling.enabled }}
-apiVersion: autoscaling/v2beta1
+apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
   name: {{ include "chart.fullname" . }}
   labels:
     {{- include "chart.labels" . | nindent 4 }}
+    {{- with .Values.autoscaling.annotations }}
+  annotations:
+      {{- toYaml . | nindent 4 }}
+    {{- end }}
 spec:
   scaleTargetRef:
     apiVersion: apps/v1
@@ -17,12 +21,15 @@ spec:
     - type: Resource
       resource:
         name: cpu
-        targetAverageUtilization: {{ .Values.autoscaling.targetCPUUtilizationPercentage }}
+        target:
+          averageUtilization: {{ .Values.autoscaling.targetCPUUtilizationPercentage }}
+          type: Utilization 
     {{- end }}
     {{- if .Values.autoscaling.targetMemoryUtilizationPercentage }}
     - type: Resource
       resource:
         name: memory
-        targetAverageUtilization: {{ .Values.autoscaling.targetMemoryUtilizationPercentage }}
+          averageUtilization: {{ .Values.autoscaling.targetMemoryUtilizationPercentage }}
+          type: Utilization
     {{- end }}
 {{- end }}

--- a/charts/sealed-secrets-ui/templates/pdb.yaml
+++ b/charts/sealed-secrets-ui/templates/pdb.yaml
@@ -1,0 +1,22 @@
+{{- if .Values.pdb.enabled }}
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "chart.fullname" . }}
+  labels:
+    {{- include "chart.labels" . | nindent 4 }}
+    {{- with .Values.pdb.annotations }}
+  annotations:
+      {{- toYaml . | nindent 4 }}
+    {{- end }}
+spec:
+  {{- if and .Values.pdb.maxUnavailable (not .Values.pdb.minAvailable) }}
+  maxUnavailable: {{ .Values.pdb.maxUnavailable }}
+  {{- else }}
+  minAvailable: {{ .Values.pdb.minAvailable | default "1" }}
+  {{- end }}
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: {{ include "chart.name" . }}
+      app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}

--- a/charts/sealed-secrets-ui/templates/service.yaml
+++ b/charts/sealed-secrets-ui/templates/service.yaml
@@ -4,6 +4,10 @@ metadata:
   name: {{ include "chart.fullname" . }}
   labels:
     {{- include "chart.labels" . | nindent 4 }}
+    {{- with .Values.service.annotations }}
+  annotations:
+      {{- toYaml . | nindent 4 }}
+    {{- end }}
 spec:
   type: {{ .Values.service.type }}
   ports:

--- a/charts/sealed-secrets-ui/values.yaml
+++ b/charts/sealed-secrets-ui/values.yaml
@@ -23,6 +23,9 @@ serviceAccount:
   # If not set and create is true, a name is generated using the fullname template
   name: ""
 
+# Deployment
+annotations: {}
+# Pod
 podAnnotations: {}
 
 podSecurityContext: {}
@@ -59,12 +62,38 @@ resources:
     cpu: 100m
     memory: 128Mi
 
+livenessProbe:
+  initialDelaySeconds: 10
+  httpGet:
+    path: /
+    port: http
+readinessProbe:
+  initialDelaySeconds: 12
+  httpGet:
+    path: /
+    port: http
+startupProbe:
+  exec:
+    command:
+      - pgrep
+      - gunicorn
+
 autoscaling:
   enabled: false
+  annotations: {}
   # minReplicas: 1
   # maxReplicas: 100
   # targetCPUUtilizationPercentage: 80
   # targetMemoryUtilizationPercentage: 80
+  
+pdb:
+  # enabled: true set minAvailable: 1 by default
+  enabled: false
+  annotations: {}
+  # minAvailable overrides maxUnavailable if both set
+  # minAvailable: 1
+  # https://raw.githubusercontent.com/kubernetes/website/main/content/en/examples/policy/zookeeper-pod-disruption-budget-maxunavailable.yaml
+  # maxUnavailable: 2
 
 nodeSelector: {}
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
-Flask==2.2.3
+Flask==2.3.3
 gunicorn==20.1.0 
 pyyaml==6.0
+werkzeug==2.3.3


### PR DESCRIPTION
Chart:
  - Updated to include common labels on all resources
  - fix `apiVersion`in hpa for k8s +1.29
  - added pdb object
  - added annotations references for all objects
  - Set startup probe (depends on procps)

Image:
  - including procps for pgrep and other procps tools (probes and lifecycle)
  - updated requirements to reflect dep changes
  
  
Chart version and appVersion updated in chart.yaml ready for release